### PR TITLE
Thermostat Screen Gauge Number Styling

### DIFF
--- a/components/ThermostatScreen/ThermostatGauge.tsx
+++ b/components/ThermostatScreen/ThermostatGauge.tsx
@@ -105,11 +105,11 @@ export const ThermostatGauge = ({
       <View style={styles.container}>
         <View style={styles.wrapper}>
           {label && <Text style={styles.label}>{label}</Text>}
+          <Text style={[styles.indoorTemp, disabled && styles.disabled]}>
+            {getLocalTemperature(interiorTemp)}&deg;
+          </Text>
           <Text style={[styles.setpoint, pendingActivity && styles.activeSetpoint, disabled && styles.disabled]}>
             {getLocalTemperature(setPoint)}&deg;
-          </Text>
-          <Text style={[styles.indoorTemp, disabled && styles.disabled]}>
-            {getLocalTemperature(interiorTemp)}&deg; Indoor
           </Text>
           <View style={styles.controls}>
             <ThermostatGaugeButton
@@ -156,10 +156,8 @@ const styles = StyleSheet.create({
     ...typography.headline3,
   },
   setpoint: {
-    ...typography.headline1,
+    ...typography.label,
     color: theme.primary,
-    textAlign: "center",
-    width: "100%",
   },
   activeSetpoint: {
     shadowOpacity: 2,
@@ -177,8 +175,10 @@ const styles = StyleSheet.create({
     color: theme.disabledText,
   },
   indoorTemp: {
-    ...typography.label,
+    ...typography.headline1,
     color: theme.primary,
+    textAlign: "center",
+    width: "100%",
   },
   controls: {
     position: "absolute",

--- a/screens/ThermostatScreen.tsx
+++ b/screens/ThermostatScreen.tsx
@@ -169,7 +169,7 @@ export function ThermostatScreen() {
                 </View>
                 <View style={styles.thermostatGauge}>
                   <ThermostatGauge
-                    label={data.mode === "auto" ? "Energy Efficient" : " "}
+                    label="Indoor"
                     disabled={isLoading}
                     pendingActivity={pendingActivity}
                     setPoint={newSetpointData.setpoint}


### PR DESCRIPTION
# Problem
- The new design requires making the indoor temperature the largest number

# Solution
- Swap the current indoor and setpoint styling
- Sets title to "Indoor"

![Screenshot 2024-02-13 at 10 58 51 AM](https://github.com/ACE-IoT-Solutions/connecting-mha-app/assets/94999450/bb2fdf15-3dc0-42ed-aac2-71df7534c9e5)

