### PR TITLE
improvement: temperature styling + dynamic styling

### DIFF
--- a/assets/svg/thermostat-down.svg
+++ b/assets/svg/thermostat-down.svg
@@ -3,7 +3,7 @@
     <path d="M13 20L20 27L27 20M20 13V26V13Z" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
 </svg> -->
 
-<svg  width="28" height="28" style="shape-rendering:geometricPrecision; text-rendering:geometricPrecision; image-rendering:optimizeQuality; fill-rule:evenodd; clip-rule:evenodd" viewBox="0 0 2048 2048">
+<svg  width="24" height="24" style="shape-rendering:geometricPrecision; text-rendering:geometricPrecision; image-rendering:optimizeQuality; fill-rule:evenodd; clip-rule:evenodd" viewBox="0 0 2048 2048">
  <defs>
   <style type="text/css">
    <![CDATA[

--- a/assets/svg/thermostat-setpoint.svg
+++ b/assets/svg/thermostat-setpoint.svg
@@ -1,4 +1,4 @@
 <svg width="23" height="23" viewBox="0 0 23 23" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <circle cx="11.9293" cy="11.1908" r="11.0506" fill="#075EA3" />
+    <circle cx="11.9293" cy="11.1908" r="11.0506" fill="#CDDFED" />
     <circle cx="11.93" cy="11.1907" r="7.73542" fill="#FFFFFF" />
 </svg>

--- a/assets/svg/thermostat-up.svg
+++ b/assets/svg/thermostat-up.svg
@@ -2,7 +2,7 @@
     <circle cx="20" cy="20" r="19" transform="rotate(-180 20 20)" stroke="#075EA3" stroke-width="2" />
     <path d="M27 20L20 13L13 20M20 27L20 14L20 27Z" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
 </svg> -->
-<svg width="28px" height="28px" viewBox="0 0 2048 2048">
+<svg width="24px" height="24px" viewBox="0 0 2048 2048">
  <defs>
   <style type="text/css">
    <![CDATA[

--- a/components/ThermostatScreen/ThermostatGauge.tsx
+++ b/components/ThermostatScreen/ThermostatGauge.tsx
@@ -259,6 +259,7 @@ const styles = StyleSheet.create({
   },
   setpoint: {
     ...typography.label,
+    fontFamily: theme.fonts.title,
     fontSize: 18,
     alignSelf: "center",
     justifyContent: "center",

--- a/components/ThermostatScreen/ThermostatGauge.tsx
+++ b/components/ThermostatScreen/ThermostatGauge.tsx
@@ -125,24 +125,34 @@ export const ThermostatGauge = ({
     <View style={styles.container}>
       <View style={styles.wrapper}>
         {label && <Text style={styles.label}>{label}</Text>}
-        <Text style={[styles.indoorTemp, pendingActivity && styles.activeSetpoint, disabled && styles.disabled]}>
-          {getLocalTemperature(interiorTemp)}&deg;
-        </Text>
+        <View style={styles.tempContainer}>
+          <Text
+            allowFontScaling={false}
+            style={[styles.indoorTemp, pendingActivity && styles.activeSetpoint, disabled && styles.disabled]}
+          >
+            {getLocalTemperature(interiorTemp)}
+          </Text>
+          <Text style={styles.degree}>&deg;</Text>
+        </View>
         {mode === "auto" ? (
-          <View style={{ flexDirection: "row" }}>
-            <View style={styles.container}>
+          <View style={{ flexDirection: "row", display: "flex" }}>
+            <View style={styles.setpointContainer}>
               <Text style={[styles.setpointLabel, disabled && styles.disabled]}>Cool</Text>
-              <Text style={[styles.setpoint, disabled && styles.disabled]}>
-                {calculateOffset(setPoint, "cool", drStatus)}&deg;
-              </Text>
+              <View style={styles.tempContainer}>
+                <Text style={[styles.setpoint, disabled && styles.disabled]}>
+                  {calculateOffset(setPoint, "cool", drStatus)}
+                </Text>
+                <Text style={styles.setpointdegree}>&deg;</Text>
+              </View>
             </View>
-            <View style={styles.spacer} />
-            <View style={styles.spacer} />
-            <View style={styles.container}>
+            <View style={styles.setpointContainer}>
               <Text style={[styles.setpointLabel, disabled && styles.disabled]}>Heat</Text>
-              <Text style={[styles.setpoint, disabled && styles.disabled]}>
-                {calculateOffset(setPoint, "heat", drStatus)}&deg;
-              </Text>
+              <View style={styles.tempContainer}>
+                <Text style={[styles.setpoint, disabled && styles.disabled]}>
+                  {calculateOffset(setPoint, "heat", drStatus)}
+                </Text>
+                <Text style={styles.setpointdegree}>&deg;</Text>
+              </View>
             </View>
           </View>
         ) : (
@@ -152,20 +162,22 @@ export const ThermostatGauge = ({
           </>
         )}
         <View style={styles.controls}>
-          <ThermostatGaugeButton
-            label="Cool"
-            icon={<ThermostatDownIcon />}
-            disabled={disabled || setPoint <= minTemp}
-            onPress={onPressCool}
-          />
-          <View style={styles.spacer} />
-          <View style={styles.spacer} />
-          <ThermostatGaugeButton
-            label="Warm"
-            icon={<ThermostatUpIcon />}
-            disabled={disabled || setPoint >= maxTemp}
-            onPress={onPressWarm}
-          />
+          <View style={styles.gauge}>
+            <ThermostatGaugeButton
+              label="Cool"
+              icon={<ThermostatDownIcon />}
+              disabled={disabled || setPoint <= minTemp}
+              onPress={onPressCool}
+            />
+          </View>
+          <View style={styles.gauge}>
+            <ThermostatGaugeButton
+              label="Warm"
+              icon={<ThermostatUpIcon />}
+              disabled={disabled || setPoint >= maxTemp}
+              onPress={onPressWarm}
+            />
+          </View>
         </View>
       </View>
       <View style={styles.dialContainer}>
@@ -181,7 +193,6 @@ export const ThermostatGauge = ({
 
 const styles = StyleSheet.create({
   container: {
-    position: "relative",
     alignItems: "center",
     flexDirection: "column",
     justifyContent: "center",
@@ -199,10 +210,31 @@ const styles = StyleSheet.create({
     flex: 1,
     color: theme.text,
   },
-  indoorTemp: {
-    ...typography.headline1,
+  tempContainer: {
     flex: 1,
+    justifyContent: "center",
+    flexDirection: "row",
+  },
+  indoorTemp: {
+    ...typography.headline1Bold,
     color: theme.primary,
+  },
+  degree: {
+    marginTop: 10,
+    fontSize: 18,
+    marginLeft: -2,
+    color: theme.primary,
+  },
+  setpointdegree: {
+    marginTop: 1,
+    fontSize: 12,
+    marginLeft: -1,
+    color: theme.primary,
+  },
+  setpointContainer: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
   },
   activeSetpoint: {
     shadowOpacity: 2,
@@ -228,9 +260,9 @@ const styles = StyleSheet.create({
   setpoint: {
     ...typography.label,
     fontSize: 18,
+    alignSelf: "center",
+    justifyContent: "center",
     color: theme.primary,
-    textAlign: "center",
-    width: "100%",
   },
   controls: {
     flex: 1,
@@ -239,6 +271,10 @@ const styles = StyleSheet.create({
     flexWrap: "wrap",
     justifyContent: "space-between",
   },
+  gauge: {
+    flex: 1,
+  },
+
   spacer: {
     width: 12,
   },

--- a/components/ThermostatScreen/ThermostatGaugeButton.tsx
+++ b/components/ThermostatScreen/ThermostatGaugeButton.tsx
@@ -22,7 +22,7 @@ export const ThermostatGaugeButton = ({ icon, label, disabled = false, onPress }
     >
       <View style={disabled && styles.disabled}>
         <View style={styles.container}>
-          <View>{icon}</View>
+          <View style={styles.icon}>{icon}</View>
         </View>
       </View>
     </TouchableOpacity>
@@ -31,11 +31,16 @@ export const ThermostatGaugeButton = ({ icon, label, disabled = false, onPress }
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: theme.backdrop,
     justifyContent: "center",
     alignItems: "center",
-    padding: 2.5,
-    borderRadius: 20,
+  },
+  icon: {
+    backgroundColor: theme.backdrop,
+    padding: 8,
+    marginTop: 2,
+    borderRadius: 30,
+    borderWidth: 1,
+    borderColor: theme.backdrop,
   },
   disabled: {
     opacity: 0.629,

--- a/theme.ts
+++ b/theme.ts
@@ -25,7 +25,6 @@ const fonts = {
   rubik300: "Rubik_300Light",
   rubik400: "Rubik_400Regular",
   rubik500: "Rubik_500Medium",
-  rubik600: "Rubik_600SemiBold",
 };
 
 export const theme = {

--- a/theme.ts
+++ b/theme.ts
@@ -25,6 +25,7 @@ const fonts = {
   rubik300: "Rubik_300Light",
   rubik400: "Rubik_400Regular",
   rubik500: "Rubik_500Medium",
+  rubik600: "Rubik_600SemiBold",
 };
 
 export const theme = {


### PR DESCRIPTION
# Problem
Based off of discussions today with MHA they have addressed a couple issues
- degree sign is too large & sets the indoor temp off center
- minimize up and down temperature buttons 
- removed font scaling for the larger indoor number

-auto selection and notification adjustment (wrapping text) (addressed by @vickiwong85 in another PR) 

# Solution
- fixed degree sign and centered temperature numbers
- bolded indoor temperature and rm ability to scale
- minimized the size of the arrows


# Screenshot
After: 
![Simulator Screenshot - iPhone 14 - 2024-02-15 at 16 38 32](https://github.com/ACE-IoT-Solutions/connecting-mha-app/assets/42820575/b20773b6-ba37-4ec3-b4da-0c519440a00a)

