### PR TITLE
improvement: navy blue text theme, weather svgs, notification updates.

### DIFF
--- a/assets/svg/alert-circle.svg
+++ b/assets/svg/alert-circle.svg
@@ -1,5 +1,5 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="12" cy="12" r="10" transform="rotate(-180 12 12)" stroke="#170B47" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<line x1="12" y1="7" x2="12" y2="13" stroke="#170B47" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M12 17L12 17.01" stroke="#170B47" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="12" cy="12" r="10" transform="rotate(-180 12 12)" stroke="#FFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<line x1="12" y1="7" x2="12" y2="13" stroke="#FFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 17L12 17.01" stroke="#FFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/assets/svg/weather/cloud-rain-light.svg
+++ b/assets/svg/weather/cloud-rain-light.svg
@@ -1,11 +1,11 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path d="M9 9C9 5.68629 11.6863 3 15 3C18.3137 3 21 5.68629 21 9C21 11.2208 19.7934 12.9626 18 14" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-    <path d="M8.30379 7.5C7.77702 7.18259 7.15983 7 6.5 7C4.567 7 3 8.567 3 10.5C3 12.433 4.567 14 6.5 14H18" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-    <line x1="18" y1="17" x2="18" y2="18" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-    <line x1="15" y1="20" x2="15" y2="21" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-    <line x1="15" y1="14" x2="15" y2="15" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-    <line x1="12" y1="17" x2="12" y2="18" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-    <line x1="9" y1="20" x2="9" y2="21" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-    <line x1="9" y1="14" x2="9" y2="15" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-    <line x1="6" y1="17" x2="6" y2="18" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M9 9C9 5.68629 11.6863 3 15 3C18.3137 3 21 5.68629 21 9C21 11.2208 19.7934 12.9626 18 14" stroke="#003A70" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M8.30379 7.5C7.77702 7.18259 7.15983 7 6.5 7C4.567 7 3 8.567 3 10.5C3 12.433 4.567 14 6.5 14H18" stroke="#003A70" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <line x1="18" y1="17" x2="18" y2="18" stroke="#003A70" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <line x1="15" y1="20" x2="15" y2="21" stroke="#003A70" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <line x1="15" y1="14" x2="15" y2="15" stroke="#003A70" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <line x1="12" y1="17" x2="12" y2="18" stroke="#003A70" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <line x1="9" y1="20" x2="9" y2="21" stroke="#003A70" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <line x1="9" y1="14" x2="9" y2="15" stroke="#003A70" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <line x1="6" y1="17" x2="6" y2="18" stroke="#003A70" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
 </svg>

--- a/assets/svg/weather/cloudy.svg
+++ b/assets/svg/weather/cloudy.svg
@@ -1,6 +1,6 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path d="M10 15C10 11.6863 12.6863 9 16 9C19.3137 9 22 11.6863 22 15C22 17.2208 20.7934 18.9626 19 20" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-    <path d="M9.30379 13.5C8.77702 13.1826 8.15983 13 7.5 13C5.567 13 4 14.567 4 16.5C4 18.433 5.567 20 7.5 20H19" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-    <path d="M8 10C8 6.68629 10.6863 4 14 4C16.0075 4 17.7848 4.98593 18.874 6.5" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-    <path d="M2 11.5C2 9.567 3.567 8 5.5 8C6.15983 8 6.77702 8.18259 7.30379 8.5" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M10 15C10 11.6863 12.6863 9 16 9C19.3137 9 22 11.6863 22 15C22 17.2208 20.7934 18.9626 19 20" stroke="#003A70" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M9.30379 13.5C8.77702 13.1826 8.15983 13 7.5 13C5.567 13 4 14.567 4 16.5C4 18.433 5.567 20 7.5 20H19" stroke="#003A70" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M8 10C8 6.68629 10.6863 4 14 4C16.0075 4 17.7848 4.98593 18.874 6.5" stroke="#003A70" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M2 11.5C2 9.567 3.567 8 5.5 8C6.15983 8 6.77702 8.18259 7.30379 8.5" stroke="#003A70" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
 </svg>

--- a/assets/svg/weather/partially-sunny.svg
+++ b/assets/svg/weather/partially-sunny.svg
@@ -1,10 +1,10 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path d="M9 17C9 13.6863 11.6863 11 15 11C18.3137 11 21 13.6863 21 17C21 19.2208 19.7934 20.9626 18 22" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-    <path d="M8.30379 15.5C7.77702 15.1826 7.15983 15 6.5 15C4.567 15 3 16.567 3 18.5C3 20.433 4.567 22 6.5 22H18" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-    <path d="M8 11C8 8.79086 9.79086 7 12 7C13.0144 7 13.9407 7.37764 14.6458 8" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-    <line x1="12" y1="4" x2="12" y2="2" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-    <line x1="12" y1="4" x2="12" y2="2" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-    <line x1="5" y1="11" x2="3" y2="11" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-    <line x1="19.071" y1="4.34317" x2="17.6568" y2="5.75738" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-    <line x1="5.41421" y1="5" x2="6.82843" y2="6.41421" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M9 17C9 13.6863 11.6863 11 15 11C18.3137 11 21 13.6863 21 17C21 19.2208 19.7934 20.9626 18 22" stroke="#003A70" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M8.30379 15.5C7.77702 15.1826 7.15983 15 6.5 15C4.567 15 3 16.567 3 18.5C3 20.433 4.567 22 6.5 22H18" stroke="#003A70" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M8 11C8 8.79086 9.79086 7 12 7C13.0144 7 13.9407 7.37764 14.6458 8" stroke="#003A70" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <line x1="12" y1="4" x2="12" y2="2" stroke="#003A70" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <line x1="12" y1="4" x2="12" y2="2" stroke="#003A70" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <line x1="5" y1="11" x2="3" y2="11" stroke="#003A70" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <line x1="19.071" y1="4.34317" x2="17.6568" y2="5.75738" stroke="#003A70" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <line x1="5.41421" y1="5" x2="6.82843" y2="6.41421" stroke="#003A70" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
 </svg>

--- a/assets/svg/weather/sun.svg
+++ b/assets/svg/weather/sun.svg
@@ -1,12 +1,22 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <rect x="8" y="8" width="8" height="8" rx="4" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-    <line x1="12" y1="5" x2="12" y2="3" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-    <line x1="12" y1="5" x2="12" y2="3" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-    <line x1="5" y1="12" x2="3" y2="12" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-    <line x1="7.75739" y1="16.6569" x2="6.34317" y2="18.0711" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-    <line x1="16.728" y1="17.3137" x2="18.1422" y2="18.7279" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-    <line x1="12" y1="21" x2="12" y2="19" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-    <line x1="21" y1="12" x2="19" y2="12" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-    <line x1="19.071" y1="5.34317" x2="17.6568" y2="6.75738" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-    <line x1="5.41421" y1="6" x2="6.82843" y2="7.41421" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <rect x="8" y="8" width="8" height="8" rx="4" stroke="#003A70
+" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <line x1="12" y1="5" x2="12" y2="3" stroke="#003A70
+" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <line x1="12" y1="5" x2="12" y2="3" stroke="#003A70
+" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <line x1="5" y1="12" x2="3" y2="12" stroke="#003A70
+" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <line x1="7.75739" y1="16.6569" x2="6.34317" y2="18.0711" stroke="#003A70
+" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <line x1="16.728" y1="17.3137" x2="18.1422" y2="18.7279" stroke="#003A70
+" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <line x1="12" y1="21" x2="12" y2="19" stroke="#003A70
+" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <line x1="21" y1="12" x2="19" y2="12" stroke="#003A70
+" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <line x1="19.071" y1="5.34317" x2="17.6568" y2="6.75738" stroke="#003A70
+" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <line x1="5.41421" y1="6" x2="6.82843" y2="7.41421" stroke="#003A70
+" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
 </svg>

--- a/assets/svg/weather/wind.svg
+++ b/assets/svg/weather/wind.svg
@@ -1,7 +1,7 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path d="M16 21C17.3807 21 18.5 19.8807 18.5 18.5C18.5 17.1193 17.3807 16 16 16" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-    <path d="M8 16L16 16" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-    <line x1="4" y1="11" x2="16" y2="11" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-    <path d="M16 11C17.3807 11 18.5 9.88071 18.5 8.5C18.5 7.11929 17.3807 6 16 6" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-    <line x1="4" y1="6" x2="9" y2="6" stroke="#075EA3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M16 21C17.3807 21 18.5 19.8807 18.5 18.5C18.5 17.1193 17.3807 16 16 16" stroke="#003A70" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M8 16L16 16" stroke="#003A70" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <line x1="4" y1="11" x2="16" y2="11" stroke="#003A70" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M16 11C17.3807 11 18.5 9.88071 18.5 8.5C18.5 7.11929 17.3807 6 16 6" stroke="#003A70" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+    <line x1="4" y1="6" x2="9" y2="6" stroke="#003A70" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
 </svg>

--- a/components/DemandResponse/DemandResponseNotification.tsx
+++ b/components/DemandResponse/DemandResponseNotification.tsx
@@ -26,7 +26,7 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     minHeight: 45,
     paddingVertical: theme.padding / 2,
-    backgroundColor: theme.primary,
+    backgroundColor: theme.colors.darkBlue,
     borderRadius: 22,
   },
   icon: {

--- a/components/DemandResponse/OptedOutNotification.tsx
+++ b/components/DemandResponse/OptedOutNotification.tsx
@@ -22,7 +22,7 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     minHeight: 45,
     paddingVertical: theme.padding / 2,
-    backgroundColor: theme.colors.periwinkle,
+    backgroundColor: theme.colors.navyBlue,
     borderRadius: 22,
   },
   icon: {
@@ -30,7 +30,7 @@ const styles = StyleSheet.create({
     marginRight: "auto",
   },
   label: {
-    color: theme.primary,
+    color: theme.colors.white,
     fontFamily: theme.fonts.title,
     paddingHorizontal: theme.padding,
     textAlign: "center",

--- a/theme.ts
+++ b/theme.ts
@@ -2,6 +2,7 @@ import { Dimensions, StyleSheet } from "react-native";
 
 export const colors = {
   darkBlue: "#075EA3",
+  navyBlue: "#003A70",
   darkBlue15pct: "rgba(23, 11, 71, 0.15)",
   darkBlue38pct: "rgba(23, 11, 71, 0.38)",
   greyBlue: "#696A86",
@@ -32,8 +33,8 @@ export const theme = {
   background: colors.lightBlue,
   backgroundMask: colors.darkBlue38pct,
   backdrop: colors.neutralBlue,
-  primary: colors.darkBlue,
-  text: colors.darkBlue,
+  primary: colors.navyBlue,
+  text: colors.navyBlue,
   disabledText: colors.greyBlue,
 
   colors: {
@@ -41,6 +42,8 @@ export const theme = {
     orange: colors.orange,
     white: colors.white,
     periwinkle: colors.periwinkle,
+    darkBlue: colors.darkBlue,
+    navyBlue: colors.navyBlue,
   },
 
   fonts: {
@@ -71,7 +74,7 @@ export const typography = StyleSheet.create({
   headline3: {
     fontFamily: fonts.arimo400,
     fontSize: 16,
-    color: colors.darkBlue,
+    color: colors.navyBlue,
   },
 
   headline3Bold: {


### PR DESCRIPTION
# Problem

A couple improvements were suggested in our phone call with Rebecca and Jeremy
They addressed the following:
- Primary text to a Navy Blue 
- Notification for opting out notification should be navy blue with white text (remove the purple, not in theme) 
- Adjust weather svg colors to match primary text theme. 


# Solution
- all issues above have been addressed 

# Screenshots
![Simulator Screenshot - iPhone SE (3rd generation) - 2024-02-27 at 15 33 32](https://github.com/ACE-IoT-Solutions/open-hems-app/assets/42820575/813153bd-ce28-41ff-ad7d-1ecba221299a)
![Simulator Screenshot - iPhone SE (3rd generation) - 2024-02-27 at 15 33 43](https://github.com/ACE-IoT-Solutions/open-hems-app/assets/42820575/52890b54-dabf-4b7f-8458-8c28c8c2c5ef)

