### PR TITLE
Improvement: adds timeout to devices fetch request

### DIFF
--- a/hooks/useDeviceListData.tsx
+++ b/hooks/useDeviceListData.tsx
@@ -8,6 +8,14 @@ export function useDeviceListData() {
   const [loading, setLoading] = useState<boolean>(false);
 
   async function getData() {
+    const timeout = 8000;
+    const controller = new AbortController();
+    const signal = controller.signal;
+
+    const timeoutId = setTimeout(() => {
+      controller.abort();
+    }, timeout);
+
     try {
       setError(false);
       setLoading(true);
@@ -18,7 +26,10 @@ export function useDeviceListData() {
         headers: {
           Authorization: `Bearer ${jwt}`,
         },
+        signal,
       });
+
+      clearTimeout(timeoutId);
 
       if (response.status !== 200) {
         throw new Error(`Status ${response.status}`);


### PR DESCRIPTION
# Problem
changing the endpoint causes an error that takes over 1 minute to load the Error Screen from the loading screen

# Solution
add a timeout for 8 seconds for the fetch request for devices using the AbortController API along with the signal option in the fetch call