### PR TITLE
fix: eco mode and adds mac address focus

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Connecting MHA",
     "slug": "connecting-mha-app",
-    "version": "0.0.30",
+    "version": "0.0.31",
     "orientation": "portrait",
     "owner": "ace-iot",
     "icon": "./assets/icon.png",
@@ -19,7 +19,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.aceiotsolutions.connecting-mha-app",
-      "buildNumber": "0.0.30",
+      "buildNumber": "0.0.31",
       "config": {
         "usesNonExemptEncryption": false
       }
@@ -29,7 +29,7 @@
         "foregroundImage": "./assets/icon.adaptive.foreground.png",
         "backgroundImage": "./assets/icon.adaptive.background.png"
       },
-      "versionCode": 30,
+      "versionCode": 31,
       "package": "com.aceiotsolutions.connecting_mha_app"
     },
     "web": {

--- a/components/ThermostatScreen/ThermostatGauge.tsx
+++ b/components/ThermostatScreen/ThermostatGauge.tsx
@@ -106,13 +106,11 @@ export const ThermostatGauge = ({
     }
   };
   const calculateOffset = (setPoint: number, type: string, drStatus: DemandResponseStatus, mode?: string) => {
-    console.log({ mode });
     let calculatedOffset = 0;
     let offset = 2;
     if (drStatus === "curtailed" || drStatus === "heightened" || mode === "eco") {
       offset += 1;
     }
-    console.log({ offset });
 
     if (type === "heat") {
       calculatedOffset = toNumber(getLocalTemperature(setPoint)) - offset;

--- a/components/ThermostatScreen/ThermostatGauge.tsx
+++ b/components/ThermostatScreen/ThermostatGauge.tsx
@@ -105,12 +105,14 @@ export const ThermostatGauge = ({
         break;
     }
   };
-  const calculateOffset = (setPoint: number, type: string, drStatus: DemandResponseStatus) => {
-    var calculatedOffset = 0;
-    var offset = 2;
-    if (drStatus === "curtailed" || drStatus === "heightened") {
-      offset = offset + 1;
+  const calculateOffset = (setPoint: number, type: string, drStatus: DemandResponseStatus, mode?: string) => {
+    console.log({ mode });
+    let calculatedOffset = 0;
+    let offset = 2;
+    if (drStatus === "curtailed" || drStatus === "heightened" || mode === "eco") {
+      offset += 1;
     }
+    console.log({ offset });
 
     if (type === "heat") {
       calculatedOffset = toNumber(getLocalTemperature(setPoint)) - offset;
@@ -140,7 +142,7 @@ export const ThermostatGauge = ({
             &deg;
           </Text>
         </View>
-        {mode === "auto" ? (
+        {mode === "auto" || mode === "eco" ? (
           <View style={{ flexDirection: "row", display: "flex" }}>
             <View style={styles.setpointContainer}>
               <Text style={[styles.setpointLabel, disabled && styles.disabled]} allowFontScaling={false}>
@@ -148,7 +150,7 @@ export const ThermostatGauge = ({
               </Text>
               <View style={styles.tempContainer}>
                 <Text style={[styles.setpoint, disabled && styles.disabled]} allowFontScaling={false}>
-                  {calculateOffset(setPoint, "cool", drStatus)}
+                  {calculateOffset(setPoint, "cool", drStatus, mode)}
                 </Text>
                 <Text style={styles.setpointdegree} allowFontScaling={false}>
                   &deg;
@@ -161,7 +163,7 @@ export const ThermostatGauge = ({
               </Text>
               <View style={styles.tempContainer}>
                 <Text style={[styles.setpoint, disabled && styles.disabled]} allowFontScaling={false}>
-                  {calculateOffset(setPoint, "heat", drStatus)}
+                  {calculateOffset(setPoint, "heat", drStatus, mode)}
                 </Text>
                 <Text style={styles.setpointdegree} allowFontScaling={false}>
                   &deg;

--- a/screens/MacAddressScreen.tsx
+++ b/screens/MacAddressScreen.tsx
@@ -14,9 +14,7 @@ import { get } from "lodash";
 
 // export const DEFAULT_MAC_ADDRESS = "8034283b1d67";
 export const DEFAULT_MAC_ADDRESS = "001122334455";
-  // const [macAddress, setMacAddress] = useState<string>("001122334455");
-
-
+// const [macAddress, setMacAddress] = useState<string>("001122334455");
 
 export function MacAddressScreen() {
   const [isModalVisible, setIsModalVisible] = useState(false);
@@ -83,16 +81,12 @@ export function MacAddressScreen() {
     setIsModalVisible(!isModalVisible);
   }
 
-  function componentWillMount() {
-    setMacAddress
-  }
-
   function ErrorModal() {
     return (
       <Modal transparent={true} visible={isModalVisible}>
         <View style={styles.errorModal}>
           <View style={styles.errorContainer}>
-            <Text style={styles.errorMessage} >{modalText}</Text>
+            <Text style={styles.errorMessage}>{modalText}</Text>
             <Button style={styles.errorButton} label="Try Again" onPress={toggleModal} />
           </View>
         </View>
@@ -120,6 +114,13 @@ export function MacAddressScreen() {
             options={{ mask: "SS:SS:SS:SS:SS:SS" }}
             onChangeText={(newMacAddress) => setMacAddress(newMacAddress.replace(/[^a-zA-Z\d]+/g, "").toLowerCase())}
             maxLength={17}
+            // selectTextOnFocus
+            onFocus={(e) =>
+              // Workaround for selectTextOnFocus={true} not working in latest React version
+              e.currentTarget.setNativeProps({
+                selection: { start: 0, end: 17 },
+              })
+            }
           />
         </View>
         <Button label="Verify" style={styles.verifyButton} onPress={verify} />


### PR DESCRIPTION
# Problem
- eco mode was only showing one temperature
- user has to highlight all mac address themselves to change it

# Solution
- fix eco mode to show both temps with higher offset
- adds workaround for selectTextOnFocus since there's an ongoing issue with the current react native version: https://github.com/facebook/react-native/issues/41988


https://github.com/ACE-IoT-Solutions/connecting-mha-app/assets/94999450/813b38d0-ec55-4f28-a601-a48a1c26407c

